### PR TITLE
fix-docker-unit-tests

### DIFF
--- a/test_ella/test_core/test_templatetags.py
+++ b/test_ella/test_core/test_templatetags.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase as UnitTestCase
+from urlparse import parse_qs
 
 from nose import tools, SkipTest
 
@@ -40,15 +41,21 @@ class TestPaginate(UnitTestCase):
             'request': req,
             'page': page
         }
-
-        tools.assert_equals((('inclusion_tags/paginator.html', 'inc/paginator.html'), {
-            'page': page,
-            'page_numbers': [1, 2, 3, 4, 5],
-            'query_params': '?using=custom_lh&other=param+with+spaces&p=',
-            'results_per_page': 10,
-            'show_first': False,
-            'show_last': True
-        }), _do_paginator(context, 2, None))
+        paginated = _do_paginator(context, 2, None)
+        paginated[1]['query_params'] = parse_qs(paginated[1]['query_params'])
+        tools.assert_equals(
+            (
+                ('inclusion_tags/paginator.html', 'inc/paginator.html'), {
+                    'page': page,
+                    'page_numbers': [1, 2, 3, 4, 5],
+                    'query_params': parse_qs('?using=custom_lh&other=param+with+spaces&p='),
+                    'results_per_page': 10,
+                    'show_first': False,
+                    'show_last': True
+                }
+            ),
+            paginated
+        )
 
     def test_always_include_given_number_of_pages(self):
         page = Paginator(range(100), 9).page(1)


### PR DESCRIPTION
There was a weird unit test failure in jenkins, probably related to small differences in libraries or os versions. It consisted of a test failure when comparing two querystrings, which contained the same key/values pairs, but it different orders. Since they were compared like a string, the test failed. 
