### PR TITLE
improvements to allow tox to be run locally

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,6 +3,8 @@ redis:
   image: redis:latest
 
 tests:
+  environment:
+    - REDIS_HOST=redis
   build: .
   links:
     - redis:redis

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist = py27
 
 [testenv]
+passenv = REDIS_HOST
 setenv =
    DJANGO_SETTINGS_MODULE=test_ella.settings
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist = py27
 [testenv]
 setenv =
    DJANGO_SETTINGS_MODULE=test_ella.settings
-   REDIS_HOST=redis
 
 commands =
   nosetests {posargs:--with-coverage --cover-package=ella --cover-erase --with-xunit}


### PR DESCRIPTION
Moved the redis host over to the docker-compose file, allowing tox to be run localy
